### PR TITLE
feat: new option importMode

### DIFF
--- a/packages/vite-plugin-voie/src/build.ts
+++ b/packages/vite-plugin-voie/src/build.ts
@@ -1,5 +1,6 @@
 import type { Plugin } from 'vite';
 import { generateRoutesCode, MODULE_NAME } from './pages';
+import { Options } from './options';
 
 /** The type of the elements of an array. */
 type ElementType<T extends Array<any>> = T extends Array<infer R> ? R : never;
@@ -7,15 +8,7 @@ type RollupPlugin = ElementType<
   NonNullable<NonNullable<Plugin['rollupInputOptions']>['plugins']>
 >;
 
-interface Options {
-  pagesDir: string;
-  supportedExtensions: string[];
-}
-
-export function createRollupPlugin({
-  pagesDir,
-  supportedExtensions,
-}: Options): RollupPlugin {
+export function createRollupPlugin(options: Options): RollupPlugin {
   return {
     name: 'voie',
     resolveId(source) {
@@ -26,7 +19,7 @@ export function createRollupPlugin({
     },
     async load(id) {
       if (id === MODULE_NAME) {
-        return await generateRoutesCode({ pagesDir, supportedExtensions });
+        return await generateRoutesCode(options);
       }
       return null;
     },

--- a/packages/vite-plugin-voie/src/index.ts
+++ b/packages/vite-plugin-voie/src/index.ts
@@ -7,6 +7,7 @@ function createPlugin(userOptions: UserOptions = {}): Plugin {
   const options: Options = {
     pagesDir: 'src/pages',
     extensions: ['vue', 'js'],
+    importMode: 'async',
     ...userOptions,
   };
 

--- a/packages/vite-plugin-voie/src/index.ts
+++ b/packages/vite-plugin-voie/src/index.ts
@@ -1,38 +1,22 @@
 import type { Plugin } from 'vite';
 import { createRollupPlugin } from './build';
+import { Options, UserOptions } from './options';
 import { createServerPlugin } from './server';
 
-/**
- * Plugin options.
- */
-export interface Options {
-  /**
-   * Relative path to the directory to search for page components.
-   * @default 'src/pages'
-   */
-  pagesDir?: string;
-  /**
-   * Valid file extensions for page components.
-   * @default ['vue', 'js']
-   */
-  extensions?: string[];
-}
+function createPlugin(userOptions: UserOptions = {}): Plugin {
+  const options: Options = {
+    pagesDir: 'src/pages',
+    extensions: ['vue', 'js'],
+    ...userOptions,
+  };
 
-function createPlugin({
-  pagesDir = 'src/pages',
-  extensions = ['vue', 'js'],
-}: Options = {}): Plugin {
   return {
-    configureServer: createServerPlugin({
-      pagesDir,
-      supportedExtensions: extensions,
-    }),
+    configureServer: createServerPlugin(options),
     rollupInputOptions: {
-      plugins: [
-        createRollupPlugin({ pagesDir, supportedExtensions: extensions }),
-      ],
+      plugins: [createRollupPlugin(options)],
     },
   };
 }
 
+export { Options, UserOptions };
 export default createPlugin;

--- a/packages/vite-plugin-voie/src/options.ts
+++ b/packages/vite-plugin-voie/src/options.ts
@@ -1,0 +1,17 @@
+/**
+ * Plugin options.
+ */
+export interface Options {
+  /**
+   * Relative path to the directory to search for page components.
+   * @default 'src/pages'
+   */
+  pagesDir: string;
+  /**
+   * Valid file extensions for page components.
+   * @default ['vue', 'js']
+   */
+  extensions: string[];
+}
+
+export type UserOptions = Partial<Options>;

--- a/packages/vite-plugin-voie/src/options.ts
+++ b/packages/vite-plugin-voie/src/options.ts
@@ -12,6 +12,14 @@ export interface Options {
    * @default ['vue', 'js']
    */
   extensions: string[];
+  /**
+   * Import routes directly or as async components
+   * @default 'async'
+   */
+  importMode: ImportMode | ImportModeResolveFn;
 }
+
+export type ImportMode = 'sync' | 'async';
+export type ImportModeResolveFn = (filepath: string) => ImportMode;
 
 export type UserOptions = Partial<Options>;

--- a/packages/vite-plugin-voie/src/pages.ts
+++ b/packages/vite-plugin-voie/src/pages.ts
@@ -1,5 +1,6 @@
 import Glob from 'glob';
 import pify from 'pify';
+import { Options } from './options';
 import { buildRoutes, stringifyRoutes } from './routes';
 
 export const MODULE_NAME = 'voie-pages';
@@ -8,15 +9,9 @@ export const MODULE_NAME = 'voie-pages';
  * Generates a string containing code that exports
  * a `routes` array that is compatible with Vue Router.
  */
-export async function generateRoutesCode({
-  pagesDir,
-  supportedExtensions,
-}: {
-  pagesDir: string;
-  supportedExtensions: string[];
-}) {
-  const files = await resolveFiles(pagesDir, supportedExtensions);
-  const routes = buildRoutes(files, pagesDir, supportedExtensions);
+export async function generateRoutesCode({ pagesDir, extensions }: Options) {
+  const files = await resolveFiles(pagesDir, extensions);
+  const routes = buildRoutes(files, pagesDir, extensions);
   const stringifiedRoutes = stringifyRoutes(routes);
 
   return `import { defineAsyncComponent } from 'vue';

--- a/packages/vite-plugin-voie/src/pages.ts
+++ b/packages/vite-plugin-voie/src/pages.ts
@@ -9,13 +9,11 @@ export const MODULE_NAME = 'voie-pages';
  * Generates a string containing code that exports
  * a `routes` array that is compatible with Vue Router.
  */
-export async function generateRoutesCode({ pagesDir, extensions }: Options) {
+export async function generateRoutesCode(options: Options) {
+  const { pagesDir, extensions } = options;
   const files = await resolveFiles(pagesDir, extensions);
   const routes = buildRoutes(files, pagesDir, extensions);
-  const stringifiedRoutes = stringifyRoutes(routes);
-
-  return `import { defineAsyncComponent } from 'vue';
-export default ${stringifiedRoutes};`.trim();
+  return stringifyRoutes(routes, options);
 }
 
 const glob = pify(Glob);

--- a/packages/vite-plugin-voie/src/server.ts
+++ b/packages/vite-plugin-voie/src/server.ts
@@ -1,22 +1,15 @@
 import type { ServerPlugin } from 'vite';
 import { generateRoutesCode, MODULE_NAME } from './pages';
+import { Options } from './options';
 
-interface Options {
-  pagesDir: string;
-  supportedExtensions: string[];
-}
-
-export function createServerPlugin({
-  pagesDir,
-  supportedExtensions,
-}: Options): ServerPlugin {
+export function createServerPlugin(options: Options): ServerPlugin {
   return ({ app }) => {
     app.use(async (ctx, next) => {
       if (
         ctx.path === `/@modules/${MODULE_NAME}` ||
         ctx.path === `/@modules/${MODULE_NAME}/index.js`
       ) {
-        ctx.body = await generateRoutesCode({ pagesDir, supportedExtensions });
+        ctx.body = await generateRoutesCode(options);
         ctx.type = 'js';
         ctx.status = 200;
         return;


### PR DESCRIPTION
close #4 

This PR adds a new option `importMode` for specifying how routes should be loaded.

It accepts a string either `async` or `sync` or a function to resolve the mode by the giving filepath. (default to `async`)

```js
{
  importMode: 'async'
}
```

```js
{
  importMode: 'sync' // all the routes are directly loaded
}
```

```js
{
  importMode(path: string) { // a custom function to resolve the mode for different paths.
    if (path.match(/my-sync-pages/))
      return 'sync'
    return 'async'
  }
}
```