### PR TITLE
chore: fix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ export default {
     voie({
       importMode(path) {
         // Load index synchronously, all other pages are async.
-        return path === '/' ? 'sync' : 'async';
+        return path.includes('index') ? 'sync' : 'async';
       },
     }),
   ],


### PR DESCRIPTION
`path` parameter is gives paths like that:

```
/src/pages/index.vue
/src/pages/hi/[name].vue
/src/pages/[...all].vue
```