### PR TITLE
fix: remove defineAsyncComponent

### DIFF
--- a/packages/vite-plugin-voie/src/routes.ts
+++ b/packages/vite-plugin-voie/src/routes.ts
@@ -172,7 +172,7 @@ function pathToName(filepath: string) {
 }
 
 export function stringifyRoutes(routes: Route[], options: Options) {
-  const imports: string[] = ['import { defineAsyncComponent } from "vue"'];
+  const imports: string[] = [];
 
   const routesCode = routes
     .map((route) => stringifyRoute(imports, route, options))
@@ -206,7 +206,7 @@ function stringifyRoute(
     imports.push(`import ${importName} from '${component}'`);
     props.push(`component: ${importName}`);
   } else {
-    props.push(`component: defineAsyncComponent(() => import('${component}'))`);
+    props.push(`component: () => import('${component}')`);
   }
 
   if (children) {


### PR DESCRIPTION
The `defineAsyncComponent` shouldn't be used with lazy loaded routes (https://next.router.vuejs.org/guide/advanced/lazy-loading.html)

All the code related to route ordering can also be removed as Vue Router handles that already but I didn't include it here

FYI: I created this PR directly from GitHub, more as a hint than an actual test. **I didn't test this works**. I created this because @antfu noticed a problem