### PR TITLE
fix: plugin order

### DIFF
--- a/packages/vite-plugin-voie/src/index.ts
+++ b/packages/vite-plugin-voie/src/index.ts
@@ -16,6 +16,7 @@ function createPlugin(userOptions: UserOptions = {}): Plugin {
 
   return {
     name: 'voie',
+    enforce: 'pre',
     resolveId(source) {
       if (source === MODULE_NAME) {
         return source;


### PR DESCRIPTION
Without `enforce: pre`, `voie-pages` get resolved as node modules before passed to the plugin.