### PR TITLE
fix: normalize file paths to fix windows issue

### DIFF
--- a/packages/vite-plugin-voie/src/generator.ts
+++ b/packages/vite-plugin-voie/src/generator.ts
@@ -9,8 +9,24 @@ import { buildRoutes, stringifyRoutes } from './routes';
  */
 export async function generateRoutesCode(options: Options) {
   const { root, pagesDir, exclude, extensions, extendRoute } = options;
-  const dir = path.join(root, pagesDir);
+  const dir = normalizePath(path.join(root, pagesDir));
   const files = await resolve({ dir, extensions, exclude });
-  const routes = buildRoutes({ files, dir, extensions, root, extendRoute });
+
+  const normalizedRoot = normalizePath(root);
+  const routes = buildRoutes({
+    files,
+    dir,
+    extensions,
+    root: normalizedRoot,
+    extendRoute,
+  });
+
   return stringifyRoutes(routes, options);
+}
+
+/**
+ * Normalizes a path to use forward slashes.
+ */
+function normalizePath(str: string): string {
+  return str.replace(/\\/g, '/');
 }

--- a/packages/vite-plugin-voie/test/routes.spec.ts
+++ b/packages/vite-plugin-voie/test/routes.spec.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { Route } from './../src/options';
 import { buildRoutes } from '../src/routes';
 
@@ -202,11 +201,11 @@ test('given a glob as pagesDir and extend route it should resolve to correct pat
 });
 
 test('given a custom root, should return the correct component path', () => {
-  const root = join(__dirname, 'app');
+  const root = 'app';
   const files = [
-    join(root, 'pages/index.vue'),
-    join(root, 'pages/user/index.vue'),
-    join(root, 'pages/user/one.vue'),
+    'app/pages/index.vue',
+    'app/pages/user/index.vue',
+    'app/pages/user/one.vue',
   ];
   const expected: Route[] = [
     {
@@ -228,7 +227,7 @@ test('given a custom root, should return the correct component path', () => {
 
   const actual = buildRoutes({
     files,
-    dir: join(root, 'pages'),
+    dir: 'app/pages',
     extensions: defaultExtensions,
     root,
   });


### PR DESCRIPTION
Ensures that paths always use forward slashes, this prevents issues when resolving routes on Windows.
Updated tests to reflect this as well.

Fixes #23 